### PR TITLE
Removed $fetchMode parameter

### DIFF
--- a/src/CachingPageRetriever.php
+++ b/src/CachingPageRetriever.php
@@ -20,12 +20,12 @@ class CachingPageRetriever implements PageRetriever {
 		$this->cache = $cache;
 	}
 
-	public function fetchPage( string $pageName, string $fetchMode ): string {
+	public function fetchPage( string $pageName ): string {
 		if ( $this->cache->contains( $pageName ) ) {
 			return $this->cache->fetch( $pageName );
 		}
 
-		$content = $this->pageRetriever->fetchPage( $pageName, $fetchMode );
+		$content = $this->pageRetriever->fetchPage( $pageName );
 
 		$this->cache->save( $pageName, $content );
 

--- a/src/LocalFilePageRetriever.php
+++ b/src/LocalFilePageRetriever.php
@@ -22,14 +22,18 @@ class LocalFilePageRetriever implements PageRetriever {
 		$this->fetcher = $fetcher;
 	}
 
-	public function fetchPage( string $filename, string $fetchMode = '' ): string {
-		$this->logger->debug( __METHOD__ . ': wiki_page', [ $filename ] );
+	public function fetchPage( string $pageName ): string {
+		$this->logger->info( 'Fetching local page', [ 'pageName' => $pageName ] );
 
 		try {
-			$content = $this->fetcher->fetchFile( $filename );
+			$content = $this->fetcher->fetchFile( $pageName );
 		}
 		catch ( FileFetchingException $ex ) {
-			$this->logger->debug( __METHOD__, [ $ex->getMessage() ] );
+			$this->logger->notice(
+				'Failed fetching local page',
+				[ 'pageName' => $pageName, 'exception' => $ex->getMessage() ]
+			);
+
 			return '';
 		}
 

--- a/src/PageRetriever.php
+++ b/src/PageRetriever.php
@@ -12,17 +12,13 @@ namespace WMDE\PageRetriever;
  */
 interface PageRetriever {
 
-	const MODE_RAW = 'raw';
-	const MODE_RENDERED = 'render';
-
 	/**
 	 * Should return an empty string on error.
 	 *
 	 * @param string $pageName
-	 * @param string $fetchMode TODO: it seems like the only mode ever used is PageRetriever::MODE_RAW
 	 *
 	 * @return string
 	 */
-	public function fetchPage( string $pageName, string $fetchMode ): string;
+	public function fetchPage( string $pageName ): string;
 
 }

--- a/tests/ApiBasedPageRetrieverTest.php
+++ b/tests/ApiBasedPageRetrieverTest.php
@@ -143,4 +143,17 @@ class ApiBasedPageRetrieverTest extends \PHPUnit_Framework_TestCase {
 		$this->pageRetriever->fetchPage( 'Lollipops' );
 		$this->pageRetriever->fetchPage( 'Rainbows' );
 	}
+
+	public function testWhenConstructingWithInvalidFetchMode_exceptionIsThrown() {
+		$this->expectException( \InvalidArgumentException::class );
+
+		$this->pageRetriever = new ApiBasedPageRetriever(
+			$this->api,
+			$this->apiUser,
+			$this->logger,
+			self::PAGE_PREFIX,
+			'~=[,,_,,]:3'
+		);
+	}
+
 }

--- a/tests/ApiBasedPageRetrieverTest.php
+++ b/tests/ApiBasedPageRetrieverTest.php
@@ -8,7 +8,6 @@ use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\Api\UsageException;
 use WMDE\PageRetriever\ApiBasedPageRetriever;
-use WMDE\PageRetriever\PageRetriever;
 use WMDE\PsrLogTestDoubles\LoggerSpy;
 
 /**
@@ -22,7 +21,7 @@ class ApiBasedPageRetrieverTest extends \PHPUnit_Framework_TestCase {
 	const PAGE_PREFIX = 'Web:SpendenseiteTestSkin/';
 
 	/**
-	 * @var \PHPUnit_Framework_MockObject_MockObject
+	 * @var \PHPUnit_Framework_MockObject_MockObject|MediawikiApi
 	 */
 	private $api;
 	private $apiUser;
@@ -65,7 +64,16 @@ class ApiBasedPageRetrieverTest extends \PHPUnit_Framework_TestCase {
 
 		$expectedContent = "Nyan\nGarfield\nFelix da House";
 		$pageName = 'Web:Spendenseite-HK2013/test/No Cats';
-		$this->assertSame( $expectedContent, $this->pageRetriever->fetchPage( $pageName, PageRetriever::MODE_RAW ) );
+
+		$this->pageRetriever = new ApiBasedPageRetriever(
+			$this->api,
+			$this->apiUser,
+			$this->logger,
+			self::PAGE_PREFIX,
+			ApiBasedPageRetriever::MODE_RAW
+		);
+
+		$this->assertSame( $expectedContent, $this->pageRetriever->fetchPage( $pageName ) );
 	}
 
 	/**
@@ -77,7 +85,7 @@ class ApiBasedPageRetrieverTest extends \PHPUnit_Framework_TestCase {
 
 		$this->pageRetriever->fetchPage( 'test page' );
 
-		$expectedLogMessage = 'WMDE\PageRetriever\ApiBasedPageRetriever::fetchPage: fail, got non-value';
+		$expectedLogMessage = 'Failed fetching page via MW API';
 		$this->assertCalledWithMessage( $expectedLogMessage );
 	}
 
@@ -100,7 +108,7 @@ class ApiBasedPageRetrieverTest extends \PHPUnit_Framework_TestCase {
 
 		$this->pageRetriever->fetchPage( 'test page' );
 
-		$expectedLogMessage = 'WMDE\PageRetriever\ApiBasedPageRetriever::fetchPage: fail, got non-value';
+		$expectedLogMessage = 'Failed fetching page via MW API';
 		$this->assertCalledWithMessage( $expectedLogMessage );
 	}
 

--- a/tests/CachingPageRetrieverTest.php
+++ b/tests/CachingPageRetrieverTest.php
@@ -30,7 +30,7 @@ class CachingPageRetrieverTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertSame(
 			self::LIVE_CONTENT,
-			$cachingRetriever->fetchPage( self::PAGE_NAME, PageRetriever::MODE_RAW )
+			$cachingRetriever->fetchPage( self::PAGE_NAME )
 		);
 	}
 
@@ -63,7 +63,7 @@ class CachingPageRetrieverTest extends \PHPUnit_Framework_TestCase {
 			$cache
 		);
 
-		$cachingRetriever->fetchPage( self::PAGE_NAME, PageRetriever::MODE_RAW );
+		$cachingRetriever->fetchPage( self::PAGE_NAME );
 
 		$this->assertSame(
 			self::LIVE_CONTENT,
@@ -82,7 +82,7 @@ class CachingPageRetrieverTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertSame(
 			self::CACHED_CONTENT,
-			$cachingRetriever->fetchPage( self::PAGE_NAME, PageRetriever::MODE_RAW )
+			$cachingRetriever->fetchPage( self::PAGE_NAME )
 		);
 	}
 


### PR DESCRIPTION
This thing has been bugging me since forever. The only implementation that uses this is
the Api based one, so the parameter has been moved to its constructor.

Note that I also changed the logging calls from debug to what I figure are more appropriate
log levels.
