### PR TITLE
allow fetching raw wikitext with expanded templates

### DIFF
--- a/tests/ApiBasedPageRetrieverTest.php
+++ b/tests/ApiBasedPageRetrieverTest.php
@@ -156,4 +156,32 @@ class ApiBasedPageRetrieverTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function testRetrieverReturnsApiResultInRawExpandedMode() {
+		$pageName = 'Raw_text';
+
+		$this->api->method( 'isLoggedin' )->willReturn( true );
+		$this->api->method( 'postRequest' )
+			->with( new SimpleRequest( 'query', $this->newParamsForExpandedTemplates( $pageName ) ) )
+			->willReturn( $this->getJsonTestData( 'mwApiRawExpanded.json' ) );
+
+		$this->pageRetriever = new ApiBasedPageRetriever(
+			$this->api,
+			$this->apiUser,
+			$this->logger,
+			self::PAGE_PREFIX,
+			ApiBasedPageRetriever::MODE_RAW_EXPANDED
+		);
+
+		$this->assertSame( 'No curly brackets here.', $this->pageRetriever->fetchPage( $pageName ) );
+	}
+
+	private function newParamsForExpandedTemplates( $pageTitle ) {
+		return [
+			'titles' => self::PAGE_PREFIX . $pageTitle,
+			'prop' => 'revisions',
+			'rvprop' => 'content',
+			'rvexpandtemplates' => '1'
+		];
+	}
+
 }

--- a/tests/data/mwApiRawExpanded.json
+++ b/tests/data/mwApiRawExpanded.json
@@ -1,0 +1,18 @@
+{
+	"query": {
+		"pages": {
+			"1292": {
+				"pageid": 1292,
+				"ns": 120,
+				"title": "Web:Spendenseite-HK2013/test/Raw text expanded templates",
+				"revisions": [
+					{
+						"contentformat": "text/x-wiki",
+						"contentmodel": "wikitext",
+						"*": "No curly brackets here."
+					}
+				]
+			}
+		}
+	}
+}


### PR DESCRIPTION
We just extracted some text into templates to make it easier to change that. Since some of the pages require to be fetched in raw mode, the PageRetriever needs to support `rvexpandtemplates` when fetching raw wikitext.